### PR TITLE
Experiment/screen coordinator

### DIFF
--- a/app/src/main/java/com/piledrive/app_gong_fu_timer_compose/ui/screens/MainScreenCoordinator.kt
+++ b/app/src/main/java/com/piledrive/app_gong_fu_timer_compose/ui/screens/MainScreenCoordinator.kt
@@ -1,0 +1,35 @@
+package com.piledrive.app_gong_fu_timer_compose.ui.screens
+
+import com.piledrive.app_gong_fu_timer_compose.data.TimerPhase
+import com.piledrive.app_gong_fu_timer_compose.ui.util.previewBooleanFlow
+import com.piledrive.app_gong_fu_timer_compose.ui.util.previewIntFlow
+import com.piledrive.app_gong_fu_timer_compose.ui.util.previewLongFlow
+import com.piledrive.app_gong_fu_timer_compose.ui.util.previewTimerPhaseFlow
+import com.piledrive.lib_compose_components.ui.dropdown.readonly.ReadOnlyDropdownCoordinator
+import kotlinx.coroutines.flow.StateFlow
+
+interface MainScreenCoordinator {
+	val startTimeDropdownCoordinator: ReadOnlyDropdownCoordinator
+	val additionalTimeDropdownCoordinator: ReadOnlyDropdownCoordinator
+	val timerPhaseState: StateFlow<TimerPhase>
+	val steepCountState: StateFlow<Int>
+	val targetSteepTimeMsState: StateFlow<Long>
+	val steepRoundProgressMsState: StateFlow<Long>
+	val keepScreenOnState: StateFlow<Boolean>
+	val onStartRound: () -> Unit
+	val onCancelRound: () -> Unit
+	val onReset: () -> Unit
+}
+
+val stubMainScreenCoordinator = object : MainScreenCoordinator {
+	override val startTimeDropdownCoordinator: ReadOnlyDropdownCoordinator = ReadOnlyDropdownCoordinator()
+	override val additionalTimeDropdownCoordinator: ReadOnlyDropdownCoordinator = ReadOnlyDropdownCoordinator()
+	override val timerPhaseState: StateFlow<TimerPhase> = previewTimerPhaseFlow()
+	override val steepCountState: StateFlow<Int> = previewIntFlow(1)
+	override val targetSteepTimeMsState: StateFlow<Long> = previewLongFlow(8000L)
+	override val steepRoundProgressMsState: StateFlow<Long> = previewLongFlow(20000L)
+	override val keepScreenOnState: StateFlow<Boolean> = previewBooleanFlow(false)
+	override val onStartRound: () -> Unit = {}
+	override val onCancelRound: () -> Unit = {}
+	override val onReset: () -> Unit = {}
+}


### PR DESCRIPTION
Use the "coordinator" pattern for collecting the various states & callbacks into one contract between a viewmodel and a screen.
Mostly reduces bloat from adding more states & callbacks to the screen tree, also lets the viewmodel keep most things private.